### PR TITLE
Lpd 54657 postgres db partitioning

### DIFF
--- a/Dockerfile.helper
+++ b/Dockerfile.helper
@@ -9,6 +9,7 @@ COPY --chown=1000:1000 ${DATA_DIRECTORY} /data/container-data
 RUN mkdir -p /data/container-data/elasticsearch
 RUN mkdir -p /data/container-data/liferay
 RUN mkdir -p /data/container-data/mysql
+RUN mkdir -p /data/container-data/postgres
 
 COPY --chown=1000:1000 dumps /data/dumps
 

--- a/Dockerfile.helper
+++ b/Dockerfile.helper
@@ -6,10 +6,9 @@ USER 1000
 
 COPY --chown=1000:1000 ${DATA_DIRECTORY} /data/container-data
 
+RUN mkdir -p /data/container-data/database
 RUN mkdir -p /data/container-data/elasticsearch
 RUN mkdir -p /data/container-data/liferay
-RUN mkdir -p /data/container-data/mysql
-RUN mkdir -p /data/container-data/postgres
 
 COPY --chown=1000:1000 dumps /data/dumps
 

--- a/README.markdown
+++ b/README.markdown
@@ -29,6 +29,7 @@ To shut down the environment, run `./gradlew composeDown`.
 - [Enable MySQL 5.7](#enable-mysql-57)
 - [Enable PostgreSQL 16.3](#enable-postgresql-163)
 - [Import a database dump](#import-a-database-dump)
+- [Enable database partitioning (MySQL and PostgreSQL only)](#enable-database-partitioning-mysql-and-postgresql-only)
 - Supports Liferay clustering OOTB
 
 ### Elasticsearch features overview
@@ -173,6 +174,16 @@ Database dump files can be added to the `./dumps` directory at the root of the W
 
 ```
 ./dumps/dumpfile.sql
+```
+
+#### Enable database partitioning (MySQL and PostgreSQL only)
+
+Set the `lr.docker.environment.database.partitioning.enabled` property to `true` or `1` in `gradle.properties`.
+
+`gradle.properties`:
+
+```properties
+lr.docker.environment.database.partitioning.enabled=true
 ```
 
 ### Elasticsearch Features

--- a/README.markdown
+++ b/README.markdown
@@ -27,6 +27,7 @@ To shut down the environment, run `./gradlew composeDown`.
 ### Database features overview
 
 - [Enable MySQL 5.7](#enable-mysql-57)
+- [Enable PostgreSQL 16.3](#enable-postgresql-163)
 - [Import a database dump](#import-a-database-dump)
 - Supports Liferay clustering OOTB
 
@@ -154,6 +155,16 @@ Set the `lr.docker.environment.service.enabled[mysql]` property to `true` or `1`
 
 ```properties
 lr.docker.environment.service.enabled[mysql]=true
+```
+
+#### Enable PostgreSQL 16.3
+
+Set the `lr.docker.environment.service.enabled[postgres]` property to `true` or `1` in `gradle.properties`.
+
+`gradle.properties`:
+
+```properties
+lr.docker.environment.service.enabled[postgres]=true
 ```
 
 #### Import a database dump

--- a/build.gradle
+++ b/build.gradle
@@ -56,7 +56,7 @@ config.composeFiles.add("docker-compose.yaml")
 Integer clusterNodes = project.getProperty("lr.docker.environment.cluster.nodes") as Integer
 def composeFiles = toList(project.getProperty("lr.docker.environment.compose.files"))
 String databaseName = project.getProperty("lr.docker.environment.database.name")
-boolean databasePartitioningEnabled = project.getProperty("lr.docker.environment.database.partitioning.enabled").toBoolean()
+String databasePartitioningEnabled = project.getProperty("lr.docker.environment.database.partitioning.enabled")
 String dataDirectory = project.getProperty("lr.docker.environment.data.directory")
 List hotfixURLs = toList(project.getProperty("lr.docker.environment.hotfix.urls"))
 String namespace = project.getProperty("lr.docker.environment.namespace")
@@ -76,7 +76,9 @@ if (databaseName != null) {
 	config.databaseName = databaseName
 }
 
-config.databasePartitioningEnabled = databasePartitioningEnabled
+if (databasePartitioningEnabled != null) {
+	config.databasePartitioningEnabled = databasePartitioningEnabled.toBoolean()
+}
 
 if (dataDirectory != null && dataDirectory.length() > 0) {
 	config.dataDirectory = dataDirectory
@@ -115,7 +117,7 @@ ConfigurableFileTree dockerComposeFileTree = project.fileTree(projectDir) {
 		include "**/liferay.*.yaml"
 	}
 
-	if(databasePartitioningEnabled) {
+	if(config.databasePartitioningEnabled) {
 		if (!config.services.any {databasePartitioningCompatibleServiceNames.contains(it)}) {
 			throw new GradleException("Database partitioning must be used with one of these databases: ${databasePartitioningCompatibleServiceNames}")
 		}

--- a/build.gradle
+++ b/build.gradle
@@ -21,12 +21,12 @@ class Config {
 	public int clusterNodes = 0
 	public List<String> composeFiles = new ArrayList<String>()
 	public String databaseName = "lportal"
+	public boolean databasePartitioningEnabled = false
 	public String dataDirectory = "data"
 	public List<String> hotfixURLs = new ArrayList<String>()
 	public String liferayDockerImageId = ""
 	public String namespace = "lrswde"
 	public List<String> services = new ArrayList<String>()
-	public boolean databasePartitioningEnabled = false
 
 	@Override
 	public String toString() {
@@ -38,12 +38,12 @@ Config:
 clusterNodes: ${clusterNodes}
 composeFiles: ${composeFiles}
 databaseName: ${databaseName}
+databasePartitioningEnabled: ${databasePartitioningEnabled}
 dataDirectory: ${dataDirectory}
 hotfixURLs: ${hotfixURLs}
 liferayDockerImageId: ${liferayDockerImageId}
 namespace: ${namespace}
 services: ${services}
-databasePartitioningEnabled: ${databasePartitioningEnabled}
 
 """
 	}
@@ -55,8 +55,9 @@ config.composeFiles.add("docker-compose.yaml")
 
 Integer clusterNodes = project.getProperty("lr.docker.environment.cluster.nodes") as Integer
 def composeFiles = toList(project.getProperty("lr.docker.environment.compose.files"))
-String dataDirectory = project.getProperty("lr.docker.environment.data.directory")
 String databaseName = project.getProperty("lr.docker.environment.database.name")
+boolean databasePartitioningEnabled = project.getProperty("lr.docker.environment.database.partitioning.enabled").toBoolean()
+String dataDirectory = project.getProperty("lr.docker.environment.data.directory")
 List hotfixURLs = toList(project.getProperty("lr.docker.environment.hotfix.urls"))
 String namespace = project.getProperty("lr.docker.environment.namespace")
 List services = project.properties.findAll {
@@ -66,7 +67,6 @@ List services = project.properties.findAll {
 }.collect {
 	it.key.substring(it.key.indexOf("[") + 1, it.key.indexOf("]"))
 }
-boolean databasePartitioningEnabled = project.getProperty("lr.docker.environment.database.partitioning.enabled").toBoolean()
 
 if (clusterNodes != null) {
 	config.clusterNodes = clusterNodes
@@ -75,6 +75,8 @@ if (clusterNodes != null) {
 if (databaseName != null) {
 	config.databaseName = databaseName
 }
+
+config.databasePartitioningEnabled = databasePartitioningEnabled
 
 if (dataDirectory != null && dataDirectory.length() > 0) {
 	config.dataDirectory = dataDirectory
@@ -93,8 +95,6 @@ if (!services.isEmpty()) {
 }
 
 config.liferayDockerImageId = "${config.namespace.toLowerCase()}-liferay"
-
-config.databasePartitioningEnabled = databasePartitioningEnabled
 
 gradle.liferayWorkspace {
 	dockerImageId = config.liferayDockerImageId

--- a/build.gradle
+++ b/build.gradle
@@ -117,7 +117,7 @@ ConfigurableFileTree dockerComposeFileTree = project.fileTree(projectDir) {
 		include "**/liferay.*.yaml"
 	}
 
-	if(config.databasePartitioningEnabled) {
+	if (config.databasePartitioningEnabled) {
 		if (!config.services.any {databasePartitioningCompatibleServiceNames.contains(it)}) {
 			throw new GradleException("Database partitioning must be used with one of these databases: ${databasePartitioningCompatibleServiceNames}")
 		}

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ static List toList(String s) {
 	return s.trim().split(",").grep()
 }
 
+String[] databasePartitioningCompatibleServiceNames = ["mysql", "postgres"]
 File projectDir = project.projectDir as File
 
 class Config {
@@ -103,10 +104,6 @@ boolean useLiferay = config.services.contains("liferay")
 
 boolean useClustering = useLiferay && config.clusterNodes > 0
 
-boolean useMysql = config.services.contains("mysql")
-
-boolean usePostgres = config.services.contains("postgres")
-
 ConfigurableFileTree dockerComposeFileTree = project.fileTree(projectDir) {
 	include "**/service.*.yaml"
 
@@ -118,7 +115,11 @@ ConfigurableFileTree dockerComposeFileTree = project.fileTree(projectDir) {
 		include "**/liferay.*.yaml"
 	}
 
-	if((useMysql || usePostgres) && databasePartitioningEnabled) {
+	if(databasePartitioningEnabled) {
+		if (!config.services.any {databasePartitioningCompatibleServiceNames.contains(it)}) {
+			throw new GradleException("Database partitioning must be used with one of these databases: ${databasePartitioningCompatibleServiceNames}")
+		}
+
 		include "**/database-partitioning.*.yaml"
 	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -25,6 +25,7 @@ class Config {
 	public String liferayDockerImageId = ""
 	public String namespace = "lrswde"
 	public List<String> services = new ArrayList<String>()
+	public boolean databasePartitioningEnabled = false
 
 	@Override
 	public String toString() {
@@ -41,6 +42,7 @@ hotfixURLs: ${hotfixURLs}
 liferayDockerImageId: ${liferayDockerImageId}
 namespace: ${namespace}
 services: ${services}
+databasePartitioningEnabled: ${databasePartitioningEnabled}
 
 """
 	}
@@ -63,6 +65,7 @@ List services = project.properties.findAll {
 }.collect {
 	it.key.substring(it.key.indexOf("[") + 1, it.key.indexOf("]"))
 }
+boolean databasePartitioningEnabled = project.getProperty("lr.docker.environment.database.partitioning.enabled").toBoolean()
 
 if (clusterNodes != null) {
 	config.clusterNodes = clusterNodes
@@ -90,6 +93,8 @@ if (!services.isEmpty()) {
 
 config.liferayDockerImageId = "${config.namespace.toLowerCase()}-liferay"
 
+config.databasePartitioningEnabled = databasePartitioningEnabled
+
 gradle.liferayWorkspace {
 	dockerImageId = config.liferayDockerImageId
 }
@@ -97,6 +102,10 @@ gradle.liferayWorkspace {
 boolean useLiferay = config.services.contains("liferay")
 
 boolean useClustering = useLiferay && config.clusterNodes > 0
+
+boolean useMysql = config.services.contains("mysql")
+
+boolean usePostgres = config.services.contains("postgres")
 
 ConfigurableFileTree dockerComposeFileTree = project.fileTree(projectDir) {
 	include "**/service.*.yaml"
@@ -107,6 +116,10 @@ ConfigurableFileTree dockerComposeFileTree = project.fileTree(projectDir) {
 
 	if (useLiferay) {
 		include "**/liferay.*.yaml"
+	}
+
+	if((useMysql || usePostgres) && databasePartitioningEnabled) {
+		include "**/database-partitioning.*.yaml"
 	}
 }
 

--- a/compose-recipes/liferay/database-partitioning.liferay.yaml
+++ b/compose-recipes/liferay/database-partitioning.liferay.yaml
@@ -1,0 +1,5 @@
+services:
+    liferay:
+        environment:
+            - LIFERAY_DATABASE_PERIOD_PARTITION_PERIOD_ENABLED=true
+            - LIFERAY_DATABASE_PERIOD_PARTITION_PERIOD_THREAD_PERIOD_POOL_PERIOD_ENABLED=true

--- a/compose-recipes/mysql/service.mysql.yaml
+++ b/compose-recipes/mysql/service.mysql.yaml
@@ -28,4 +28,4 @@ services:
               target: /var/lib/mysql
               type: volume
               volume:
-                  subpath: container-data/mysql
+                  subpath: container-data/database

--- a/compose-recipes/postgres/clustering.postgres.yaml
+++ b/compose-recipes/postgres/clustering.postgres.yaml
@@ -1,0 +1,7 @@
+services:
+    liferay-cluster-node:
+        environment:
+            - LIFERAY_JDBC_PERIOD_DEFAULT_PERIOD_DRIVER_UPPERCASEC_LASS_UPPERCASEN_AME=org.postgresql.Driver
+            - LIFERAY_JDBC_PERIOD_DEFAULT_PERIOD_PASSWORD=password
+            - LIFERAY_JDBC_PERIOD_DEFAULT_PERIOD_URL=jdbc:postgresql://database:5432/${DATABASE_NAME}
+            - LIFERAY_JDBC_PERIOD_DEFAULT_PERIOD_USERNAME=liferay

--- a/compose-recipes/postgres/liferay.postgres.yaml
+++ b/compose-recipes/postgres/liferay.postgres.yaml
@@ -1,0 +1,10 @@
+services:
+    liferay:
+        depends_on:
+            database:
+                condition: service_healthy
+        environment:
+            - LIFERAY_JDBC_PERIOD_DEFAULT_PERIOD_DRIVER_UPPERCASEC_LASS_UPPERCASEN_AME=org.postgresql.Driver
+            - LIFERAY_JDBC_PERIOD_DEFAULT_PERIOD_PASSWORD=password
+            - LIFERAY_JDBC_PERIOD_DEFAULT_PERIOD_URL=jdbc:postgresql://database:5432/${DATABASE_NAME}
+            - LIFERAY_JDBC_PERIOD_DEFAULT_PERIOD_USERNAME=liferay

--- a/compose-recipes/postgres/service.postgres.yaml
+++ b/compose-recipes/postgres/service.postgres.yaml
@@ -32,4 +32,4 @@ services:
                 target: /var/lib/postgresql/data
                 type: volume
                 volume:
-                    subpath: container-data/postgres
+                    subpath: container-data/database

--- a/compose-recipes/postgres/service.postgres.yaml
+++ b/compose-recipes/postgres/service.postgres.yaml
@@ -1,0 +1,35 @@
+services:
+    database:
+        image: postgres:16.3
+        container_name: "${NAMESPACE}-database-postgres"
+        shm_size: 128mb
+        environment:
+            - POSTGRES_DB=${DATABASE_NAME}
+            - POSTGRES_USER=liferay
+            - POSTGRES_PASSWORD=password
+        healthcheck:
+            interval: 5s
+            retries: 50
+            start_period: 30s
+            test: "pg_isready -U liferay -d ${DATABASE_NAME}"
+            timeout: 5s
+        ports:
+            - "5433:5432"
+        deploy:
+            resources:
+                limits:
+                    memory: 1G
+                reservations:
+                    memory: 1G
+        volumes:
+            -   read_only: true
+                source: data-volume
+                target: /docker-entrypoint-initdb.d
+                type: volume
+                volume:
+                    subpath: dumps
+            -   source: data-volume
+                target: /var/lib/postgresql/data
+                type: volume
+                volume:
+                    subpath: container-data/postgres

--- a/gradle.properties
+++ b/gradle.properties
@@ -60,6 +60,11 @@ lr.docker.environment.database.name=lportal
 
 # Optional
 #
+# Set to "true" or "1" if you want to enable database partitioning (MySQL or PostgreSQL only)
+lr.docker.environment.database.partitioning.enabled=false
+
+# Optional
+#
 # Comma-separated list of URLs pointing to hotfixes. These will be automatically
 # downloaded and copied to the Liferay container before startup.
 lr.docker.environment.hotfix.urls=

--- a/gradle.properties
+++ b/gradle.properties
@@ -42,6 +42,7 @@ lr.docker.environment.compose.files=
 lr.docker.environment.service.enabled[elasticsearch]=false
 lr.docker.environment.service.enabled[liferay]=true
 lr.docker.environment.service.enabled[mysql]=false
+lr.docker.environment.service.enabled[postgres]=false
 
 # Optional
 #


### PR DESCRIPTION
@annasuszter will you please give my changes a review and confirm that everything works as expected?

This contains two meaningful changes:
1. Both database services are mapped to the `database` subdir in the data container, instead of creating both `mysql` and `postgres`. This assumes we will never have multiple database services at the same time, and aligns with the current pattern of both having the `database` key in the compose yaml files.
2. An exception is thrown if database partitioning is enabled but no external database is configured. The intent is to make it very clear what is wrong, instead of silently continuing without partitioning enabled. We'd rather be loud and clear rather than sneaky and surprising.