### PR TITLE
LPD-54657 Update listAdminUsers to handle database partitioning

### DIFF
--- a/buildSrc/src/main/groovy/docker-common.gradle
+++ b/buildSrc/src/main/groovy/docker-common.gradle
@@ -78,6 +78,55 @@ ext {
 		}
 	}
 
+	getDefaultVirtualHost = {
+		List<Map<String, String>> companyVirtualHosts ->
+
+		Map<String, String> defaultCompanyVirtualHost = null
+
+		file("configs/common/portal-ext.properties").eachLine {
+			String line = it.trim()
+
+			if (line.startsWith("company.default.web.id=")) {
+				String webId = line.split("=")[1]
+
+				defaultCompanyVirtualHost = companyVirtualHosts.find {
+					it["webId"] == webId
+				}
+			}
+		}
+
+		if (defaultCompanyVirtualHost == null) {
+			defaultCompanyVirtualHost = companyVirtualHosts.find {
+				it["webId"] == "liferay.com"
+			}
+		}
+
+		if (defaultCompanyVirtualHost == null) {
+			throw new GradleException("Unable to auto-detect company.default.web.id, please set it in configs/common/portal-ext.properties")
+		}
+
+		return defaultCompanyVirtualHost["webId"]
+	}
+
+	forEachCompanyId = {
+		Closure<Void> action ->
+
+		List<Map<String, String>> companyVirtualHosts = executeSQLQuery("select companyId, hostname, webId from VirtualHost inner join Company using (companyId) where layoutSetId = 0", config.databaseName)
+
+		String defaultWebId = getDefaultVirtualHost(companyVirtualHosts)
+
+		companyVirtualHosts.each {
+			try {
+				String schema = config.databasePartitioningEnabled && it["webId"] != defaultWebId ? "lpartition_${it["companyId"]}" : config.databaseName
+
+				action(it["companyId"], it["hostname"], it["webId"], schema)
+			}
+			catch (Exception e) {
+				e.printStackTrace()
+			}
+		}
+	}
+
 	updateGradleLocalProperties = {
 		Map<String, String> newProperties ->
 

--- a/buildSrc/src/main/groovy/docker-liferay-bundle.gradle
+++ b/buildSrc/src/main/groovy/docker-liferay-bundle.gradle
@@ -124,8 +124,14 @@ tasks.register("listAdminUsers") {
 		config.useDatabase
 	}
 
-	doFirst {
-		List results = executeSQLQuery("select screenName, emailAddress from User_ where userId in (select userId from Users_Roles where roleId in (select roleId from Role_ where name = 'Administrator'))", config.databaseName)
+	Closure<Void> listAdminUsersForCompany = {
+		String companyId, String hostname, String webId, String schema ->
+
+		List results = executeSQLQuery("select screenName, emailAddress from User_ where companyId = ${companyId} and userId in (select userId from Users_Roles where roleId in (select roleId from Role_ where name = 'Administrator'))", schema)
+
+		println "\nhttp://${hostname}:8080/c/portal/login"
+		println "http://${hostname}:8080/?p_p_id=com_liferay_login_web_portlet_LoginPortlet&p_p_lifecycle=0&p_p_state=exclusive&p_p_mode=view&_com_liferay_login_web_portlet_LoginPortlet_mvcRenderCommandName=%2Flogin%2Flogin&saveLastPath=false"
+		println getDatabaseAccessCommand(schema)
 
 		if (results.isEmpty()) {
 			println "Unable to detect users explicitly granted the Administrator role"
@@ -137,5 +143,9 @@ tasks.register("listAdminUsers") {
 				println " - ${it["screenName"]} (${it["emailAddress"]})"
 			}
 		}
+	}
+
+	doFirst {
+		forEachCompanyId listAdminUsersForCompany
 	}
 }


### PR DESCRIPTION
This update allows us to handle database partitioning and list admin users across multiple portal instances and schemas. It also prints out the docker compose command used to access each of the partitions.