### PR TITLE
LPD-54657 Allow users to setup SaaS environment (database)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 **/.settings
 **/.web_bundle_build
 **/activation-key-*.xml
+**/*dxp-license-*.xml
 **/bin
 **/build
 **/build_gradle

--- a/build.gradle
+++ b/build.gradle
@@ -92,6 +92,8 @@ buildDockerImage {
 	onlyIf("using the Liferay service") {
 		config.useLiferay
 	}
+
+	dependsOn ":checkForLiferayLicense"
 }
 
 clean {
@@ -118,7 +120,6 @@ composeUp {
 	}
 
 	dependsOn ":buildDockerImage"
-	dependsOn ":checkForLiferayLicense"
 
 	doFirst {
 		println "Using config:\n\n${config}\n\n"

--- a/buildSrc/src/main/groovy/com/liferay/docker/workspace/environments/Util.groovy
+++ b/buildSrc/src/main/groovy/com/liferay/docker/workspace/environments/Util.groovy
@@ -1,5 +1,7 @@
 package com.liferay.docker.workspace.environments
 
+import org.gradle.api.file.FileCollection
+
 class Util {
 
 	public static String fixReleaseKey(String releaseKey) {
@@ -21,6 +23,14 @@ class Util {
 		}
 
 		return releaseKey
+	}
+
+	public static boolean isEmpty(FileCollection fileCollection) {
+		if (fileCollection == null) {
+			return true
+		}
+
+		return fileCollection.isEmpty()
 	}
 
 }

--- a/buildSrc/src/main/groovy/docker-liferay-bundle.gradle
+++ b/buildSrc/src/main/groovy/docker-liferay-bundle.gradle
@@ -2,10 +2,60 @@ import com.liferay.docker.workspace.environments.Util
 
 import de.undercouch.gradle.tasks.download.Download
 
+import groovy.xml.XmlSlurper
+import groovy.xml.slurpersupport.GPathResult
+
 import java.nio.file.Path
 import java.nio.file.Paths
 
 project.plugins.apply "docker-common"
+
+Closure<Boolean> isValidLicenseFile = {
+	File licenseFile ->
+
+	String licenseText = licenseFile.text
+
+	if (!licenseText.contains("<license>")) {
+		return false
+	}
+
+	XmlSlurper xmlSlurper = new XmlSlurper()
+
+	GPathResult gPathResult = xmlSlurper.parse(licenseFile)
+	String expirationDateText = gPathResult["expiration-date"].text()
+
+	if (new Date(expirationDateText).after(new Date())) {
+		return true
+	}
+
+	println "License file ${licenseFile.absolutePath} expired on ${expirationDateText}"
+
+	licenseFile.delete()
+
+	return false
+}
+
+Closure<FileCollection> copyLiferayLicenseFromDXPImage = {
+	String imageName ->
+
+	if ((imageName == null) || !imageName.contains(".q")) {
+		return null
+	}
+
+	String temporaryContainerName = "${config.namespace.toLowerCase()}-license-check"
+	String temporaryVolumeName = "${config.namespace.toLowerCase()}-license"
+
+	waitForCommand("docker create --name=${temporaryContainerName} --volume=${temporaryVolumeName}:/opt/liferay/deploy ${imageName}")
+	waitForCommand("docker run --rm -v ${temporaryVolumeName}:/source -v ./configs/common/osgi/modules/:/target alpine sh -c 'cp /source/trial-*.xml /target/'")
+	waitForCommand("docker rm ${temporaryContainerName}")
+	waitForCommand("docker volume rm ${config.namespace.toLowerCase()}-license")
+
+	return project.fileTree("configs") {
+		include "**/osgi/modules/*.xml"
+	}.filter {
+		isValidLicenseFile(it)
+	}
+}
 
 tasks.register("checkForLiferayLicense") {
 	onlyIf("using the Liferay service") {
@@ -19,11 +69,35 @@ tasks.register("checkForLiferayLicense") {
 		FileCollection licenseXmlFileCollection = project.fileTree("configs") {
 			include "**/osgi/modules/*.xml"
 		}.filter {
-			it.text.contains("<license>")
+			isValidLicenseFile(it)
 		}
 
 		if (licenseXmlFileCollection.isEmpty()) {
-			throw new GradleException("Please add a license to configs/common/osgi/modules/")
+			licenseXmlFileCollection = copyLiferayLicenseFromDXPImage(project.gradle.liferayWorkspace.dockerImageLiferay)
+		}
+
+		if (licenseXmlFileCollection == null || licenseXmlFileCollection.isEmpty()) {
+			List<String> dxpImageTagNames = waitForCommand("docker image ls liferay/dxp:*.q* --format='{{ .Tag }}'").split("\n").collect {
+				it.trim()
+			}
+
+			String latestQuarterlyRelease = dxpImageTagNames.collect {
+				it.substring(0, it.indexOf(".q") + 3)
+			}.sort().last()
+
+			String latestQuarterlyReleaseTag = dxpImageTagNames.findAll {
+				it.startsWith(latestQuarterlyRelease)
+			}.sort {
+				String a, String b ->
+
+				return Integer.parseInt(a.substring(it.indexOf(".q" + 4)).split("-")[0]) - Integer.parseInt(b.substring(it.indexOf(".q" + 4)).split("-")[0])
+			}.last()
+
+			licenseXmlFileCollection = copyLiferayLicenseFromDXPImage("liferay/dxp:" + latestQuarterlyReleaseTag)
+		}
+
+		if (licenseXmlFileCollection == null || licenseXmlFileCollection.isEmpty()) {
+			throw new GradleException("Please add a non-expired license to configs/common/osgi/modules/")
 		}
 	}
 }

--- a/buildSrc/src/main/groovy/docker-liferay-bundle.gradle
+++ b/buildSrc/src/main/groovy/docker-liferay-bundle.gradle
@@ -38,7 +38,7 @@ Closure<Boolean> isValidLicenseFile = {
 Closure<FileCollection> copyLiferayLicenseFromDXPImage = {
 	String imageName ->
 
-	if ((imageName == null) || !imageName.contains(".q")) {
+	if ((imageName == null) || !(imageName.contains(".q") || imageName.contains("latest"))) {
 		return null
 	}
 
@@ -94,6 +94,10 @@ tasks.register("checkForLiferayLicense") {
 			}.last()
 
 			licenseXmlFileCollection = copyLiferayLicenseFromDXPImage("liferay/dxp:" + latestQuarterlyReleaseTag)
+		}
+
+		if (Util.isEmpty(licenseXmlFileCollection)) {
+			licenseXmlFileCollection = copyLiferayLicenseFromDXPImage("liferay/dxp:latest")
 		}
 
 		if (Util.isEmpty(licenseXmlFileCollection)) {

--- a/buildSrc/src/main/groovy/docker-liferay-bundle.gradle
+++ b/buildSrc/src/main/groovy/docker-liferay-bundle.gradle
@@ -72,11 +72,11 @@ tasks.register("checkForLiferayLicense") {
 			isValidLicenseFile(it)
 		}
 
-		if (licenseXmlFileCollection.isEmpty()) {
+		if (Util.isEmpty(licenseXmlFileCollection)) {
 			licenseXmlFileCollection = copyLiferayLicenseFromDXPImage(project.gradle.liferayWorkspace.dockerImageLiferay)
 		}
 
-		if (licenseXmlFileCollection == null || licenseXmlFileCollection.isEmpty()) {
+		if (Util.isEmpty(licenseXmlFileCollection)) {
 			List<String> dxpImageTagNames = waitForCommand("docker image ls liferay/dxp:*.q* --format='{{ .Tag }}'").split("\n").collect {
 				it.trim()
 			}
@@ -96,7 +96,7 @@ tasks.register("checkForLiferayLicense") {
 			licenseXmlFileCollection = copyLiferayLicenseFromDXPImage("liferay/dxp:" + latestQuarterlyReleaseTag)
 		}
 
-		if (licenseXmlFileCollection == null || licenseXmlFileCollection.isEmpty()) {
+		if (Util.isEmpty(licenseXmlFileCollection)) {
 			throw new GradleException("Please add a non-expired license to configs/common/osgi/modules/")
 		}
 	}


### PR DESCRIPTION
This is an update for [LPD-54657](https://liferay.atlassian.net/browse/LPD-54657).

@holatuwol I added a check on the `latest` tag if no valid license is found in existing images. Would this be too heavy? Hopefully it would be a one-time large cost, as subsequent downloads of the `latest` tag seem to be much faster given that most of the common layers are already downloaded at that point.